### PR TITLE
Add POC support for tagged template literals

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -1,0 +1,53 @@
+export default ([headings], ...data) => {
+  const keys = headings.replace(/\s/g, '').split('|');
+
+  // TODO: should this throw a warning? when not enough args are supplied
+  // console.log(data.length % keys.length === 0)
+
+  const keysLength = keys.length;
+
+  const parameterRows = Array
+    .from({ length: data.length / keysLength })
+    .map((_, index) => data.slice((index * keysLength), (index * keysLength) + keysLength))
+    .map(row => row.reduce((acc, value, index) => ({ ...acc, [keys[index]]: value }), {}));
+
+  const tests = parameterisedTests(parameterRows);
+
+  const globalTest = global.test;
+  const test = tests(globalTest);
+  test.skip = tests(globalTest.skip);
+  test.only = tests(globalTest.only);
+
+  const globalIt = global.it;
+  const it = tests(globalIt);
+  it.skip = tests(globalIt.skip);
+  it.only = tests(globalIt.only);
+
+  const xtest = tests(global.xtest);
+  const xit = tests(global.xit);
+  const fit = tests(global.fit);
+
+  const globalDescribe = global.describe;
+  const describe = tests(globalDescribe);
+  describe.skip = tests(globalDescribe.skip);
+  describe.only = tests(globalDescribe.only);
+  const fdescribe = tests(global.fdescribe);
+  const xdescribe = tests(global.xdescribe);
+
+  return { test, xtest, it, xit, fit, describe, fdescribe, xdescribe };
+};
+
+const interpolate = (title, data) => {
+  const keys = Object.keys(data);
+  return keys.reduce((acc, key) => acc.replace('$' + key, data[key]), title);
+};
+
+const parameterisedTests = parameterRows => globalCb => (title, test) => {
+  parameterRows.forEach(params => globalCb(interpolate(title, params), applyTestParams(params, test)));
+};
+
+const applyTestParams = (params, test) => {
+  if (test.length > 1) return done => test(params, done);
+
+  return () => test(params);
+};

--- a/src/template.spec.js
+++ b/src/template.spec.js
@@ -1,0 +1,21 @@
+import each from './template';
+
+describe('.add', () => {
+  each`
+    a    | b    | expected
+    ${0} | ${0} | ${0}
+    ${0} | ${1} | ${1}
+    ${1} | ${1} | ${2}
+  `.test('returns $expected when given $a and $b', ({ a, b, expected }) => {
+    expect(a + b).toBe(expected);
+  });
+});
+
+describe('.join', () => {
+  each`
+    array        | delimiter | expected
+    ${[0, 1, 2]} | ${'*'}    | ${'0*1*2'}
+  `.test('returns $expected when given $array is joined with $delimiter', ({ array, delimiter, expected }) => {
+    expect(array.join(delimiter)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Proves the concept of using tagged template literals for data tables in `Jest`.

Related to https://github.com/facebook/jest/issues/6082

Example of how tests could be written:

```js
describe('.add', () => {
  each`
    a    | b    | expected
    ${0} | ${0} | ${0}
    ${0} | ${1} | ${1}
    ${1} | ${1} | ${2}
  `.test('returns $expected when given $a and $b', ({ a, b, expected }) => {
    expect(a + b).toBe(expected);
  });
});

describe('.join', () => {
  each`
    array        | delimiter | expected
    ${[0, 1, 2]} | ${'*'}    | ${'0*1*2'}
  `.test('returns $expected when given $array is joined with $delimiter', ({ array, delimiter, expected }) => {
    expect(array.join(delimiter)).toBe(expected);
  });
});

↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
```

<img width="777" alt="screen shot 2018-04-28 at 01 11 24" src="https://user-images.githubusercontent.com/5610087/39389532-57af34dc-4a81-11e8-9d08-3c4662c76cbe.png">


/cc @SimenB